### PR TITLE
build: Add a check step to better integrate with zls

### DIFF
--- a/Payload_Type/rango/rango/agent_code/build.zig
+++ b/Payload_Type/rango/rango/agent_code/build.zig
@@ -62,6 +62,13 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
 
+    const exe_check = b.addExecutable(.{
+        .name = "rango_check",
+        .root_module = exe_mod,
+    });
+    const check = b.step("check", "Check the app");
+    check.dependOn(&exe_check.step);
+
     const run_cmd = b.addRunArtifact(exe);
 
     run_cmd.step.dependOn(b.getInstallStep());


### PR DESCRIPTION
The check build step added here is designed to give a [better experience with zls](https://zigtools.org/zls/guides/build-on-save/)