### PR TITLE
Test: Cases for most of the commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,11 @@ Please follow the steps below to contribute to this project:
 
 > Should you have any questions or bugs to report, please open an issue on the 
 > [issue tracker](https://github.com/pop-ecx/rango/issues).
+
+### Tests
+Current tests are stored in the `tests/` directory. To run individual tests
+
+`zig test tests/<test_file_name>.zig` for example, `zig test tests/execute_ls_test.zig`.
+
+To run all tests, it is advised to run `zig test tests/main.zig`. This is done as
+a hacky workaround to this [known issue](https://ziggit.dev/t/working-unit-tests-fail-when-started-from-zig-build-test/15197). Avoid running `zig build test` directly as it will incorrectly report failed runs.

--- a/Payload_Type/rango/rango/agent_code/build.zig
+++ b/Payload_Type/rango/rango/agent_code/build.zig
@@ -80,12 +80,19 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const exe_unit_tests = b.addTest(.{
-        .root_module = exe_mod,
+    const test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/main.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
-    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const exe_unit_tests = b.addTest(.{
+        .root_module = test_mod,
+    });
+
+    const run_unit_tests = b.addRunArtifact(exe_unit_tests);
+
 
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&run_unit_tests.step);
 }

--- a/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const json = std.json;
+
+const CommandExecutor = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+
+    fn executeCat(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
+        const ExecuteCatParameters = struct { path: []const u8 };
+        const parsed = try json.parseFromSlice(ExecuteCatParameters, self.allocator, raw_json, .{});
+        defer parsed.deinit();
+
+        const path = parsed.value.path;
+        if (path.len == 0) return try self.allocator.dupe(u8, "No path provided");
+
+        _ = std.Io.Dir.cwd().statFile(self.io, path, .{}) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error reading file: {}", .{err});
+        };
+ 
+        const content = std.Io.Dir.cwd().readFileAlloc(self.io, path, self.allocator, .limited(1024 * 1024)) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error reading file: {s}", .{@errorName(err)});
+        };
+        defer self.allocator.free(content);
+        return try self.allocator.dupe(u8, "Success");
+    }
+};
+
+test "Read existing file successfully" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+    const io = threaded.io(); 
+    const dir = std.Io.Dir.cwd();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = io};
+    try std.Io.Dir.writeFile(dir, io, .{ .sub_path = "./testr", .data = "AAAAAAAAAAAAAAA", .flags = .{ .permissions = .default_file }});
+    const case = "{\"path\": \"./testr\"}";
+    const output = try executor.executeCat(case);
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("Success", output);
+}
+
+test "Reading non existing file failure" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+    const io = threaded.io(); 
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = io};
+    const case = "{\"path\": \"./non_existent_file\"}";
+    const output = try executor.executeCat(case);
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("Error reading file: error.FileNotFound", output);
+}
+
+test "Reading a blank file path failure" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+    const io = threaded.io(); 
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = io};
+    const case = "{\"path\": \"\"}";
+    const output = try executor.executeCat(case);
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("No path provided", output);
+}

--- a/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
@@ -33,8 +33,8 @@ test "Read existing file successfully" {
     const dir = std.Io.Dir.cwd();
 
     var executor = CommandExecutor{ .allocator = gpa, .io = io };
-    try std.Io.Dir.writeFile(dir, io, .{ .sub_path = "./testr", .data = "AAAAAAAAAAAAAAA", .flags = .{ .permissions = .default_file } });
-    const case = "{\"path\": \"./testr\"}";
+    try std.Io.Dir.writeFile(dir, io, .{ .sub_path = "./tests/testr", .data = "AAAAAAAAAAAAAAA", .flags = .{ .permissions = .default_file } });
+    const case = "{\"path\": \"./tests/testr\"}";
     const output = try executor.executeCat(case);
     defer gpa.free(output);
     try std.testing.expectEqualStrings("Success", output);

--- a/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_cat_test.zig
@@ -16,7 +16,7 @@ const CommandExecutor = struct {
         _ = std.Io.Dir.cwd().statFile(self.io, path, .{}) catch |err| {
             return try std.fmt.allocPrint(self.allocator, "Error reading file: {}", .{err});
         };
- 
+
         const content = std.Io.Dir.cwd().readFileAlloc(self.io, path, self.allocator, .limited(1024 * 1024)) catch |err| {
             return try std.fmt.allocPrint(self.allocator, "Error reading file: {s}", .{@errorName(err)});
         };
@@ -27,13 +27,13 @@ const CommandExecutor = struct {
 
 test "Read existing file successfully" {
     var gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
-    const io = threaded.io(); 
+    const io = threaded.io();
     const dir = std.Io.Dir.cwd();
 
-    var executor = CommandExecutor{ .allocator = gpa, .io = io};
-    try std.Io.Dir.writeFile(dir, io, .{ .sub_path = "./testr", .data = "AAAAAAAAAAAAAAA", .flags = .{ .permissions = .default_file }});
+    var executor = CommandExecutor{ .allocator = gpa, .io = io };
+    try std.Io.Dir.writeFile(dir, io, .{ .sub_path = "./testr", .data = "AAAAAAAAAAAAAAA", .flags = .{ .permissions = .default_file } });
     const case = "{\"path\": \"./testr\"}";
     const output = try executor.executeCat(case);
     defer gpa.free(output);
@@ -42,11 +42,11 @@ test "Read existing file successfully" {
 
 test "Reading non existing file failure" {
     var gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
-    const io = threaded.io(); 
+    const io = threaded.io();
 
-    var executor = CommandExecutor{ .allocator = gpa, .io = io};
+    var executor = CommandExecutor{ .allocator = gpa, .io = io };
     const case = "{\"path\": \"./non_existent_file\"}";
     const output = try executor.executeCat(case);
     defer gpa.free(output);
@@ -55,11 +55,11 @@ test "Reading non existing file failure" {
 
 test "Reading a blank file path failure" {
     var gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
-    const io = threaded.io(); 
+    const io = threaded.io();
 
-    var executor = CommandExecutor{ .allocator = gpa, .io = io};
+    var executor = CommandExecutor{ .allocator = gpa, .io = io };
     const case = "{\"path\": \"\"}";
     const output = try executor.executeCat(case);
     defer gpa.free(output);

--- a/Payload_Type/rango/rango/agent_code/tests/execute_commands_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_commands_test.zig
@@ -3,6 +3,7 @@ const json = std.json;
 
 const CommandExecutor = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
 
     fn executeShell(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
         const ShellParameters = struct { command: []const u8 };
@@ -12,8 +13,7 @@ const CommandExecutor = struct {
         const command = parsed.value.command;
         if (command.len == 0) return "No command provided";
 
-        const result = try std.process.Child.run(.{
-            .allocator = self.allocator,
+        const result = try std.process.run(self.allocator, self.io, .{
             .argv = &[_][]const u8{ "/bin/sh", "-c", command },
         });
 
@@ -28,10 +28,13 @@ const CommandExecutor = struct {
 };
 
 test "shell command execution via JSON" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
 
-    var executor = CommandExecutor{ .allocator = allocator };
+    var executor = CommandExecutor{ .allocator = allocator, .io = io };
 
     const cases = [_][]const u8{
         "{\"command\": \"ls\"}",

--- a/Payload_Type/rango/rango/agent_code/tests/execute_delete_directory_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_delete_directory_test.zig
@@ -18,7 +18,7 @@ const CommandExecutor = struct {
         };
 
         std.Io.Dir.cwd().deleteTree(self.io, path) catch |err| {
-            return try std.fmt.allocPrint(self.allocator, "Error deleting directory: {s}",  .{@errorName(err)});
+            return try std.fmt.allocPrint(self.allocator, "Error deleting directory: {s}", .{@errorName(err)});
         };
         return try self.allocator.dupe(u8, "Success");
     }
@@ -35,7 +35,7 @@ test "Delete directory success case" {
 
     var executor = CommandExecutor{ .allocator = allocator, .io = threaded.io() };
 
-    try std.Io.Dir.createDir(dir, io, "test_dir", .default_dir );
+    try std.Io.Dir.createDir(dir, io, "test_dir", .default_dir);
 
     const case = "{\"path\": \"test_dir\"}";
     const output = try executor.executeDeleteDirectory(case);

--- a/Payload_Type/rango/rango/agent_code/tests/execute_delete_directory_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_delete_directory_test.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const json = std.json;
+
+const CommandExecutor = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+
+    fn executeDeleteDirectory(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
+        const DeleteDirectoryParameters = struct { path: []const u8 };
+        const parsed = try json.parseFromSlice(DeleteDirectoryParameters, self.allocator, raw_json, .{});
+        defer parsed.deinit();
+
+        const path = parsed.value.path;
+        if (path.len == 0) return try self.allocator.dupe(u8, "No path provided");
+
+        _ = std.Io.Dir.cwd().statFile(self.io, path, .{}) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error deleting directory: {}", .{err});
+        };
+
+        std.Io.Dir.cwd().deleteTree(self.io, path) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error deleting directory: {s}",  .{@errorName(err)});
+        };
+        return try self.allocator.dupe(u8, "Success");
+    }
+};
+
+test "Delete directory success case" {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    const dir = std.Io.Dir.cwd();
+    const io = threaded.io();
+
+    var executor = CommandExecutor{ .allocator = allocator, .io = threaded.io() };
+
+    try std.Io.Dir.createDir(dir, io, "test_dir", .default_dir );
+
+    const case = "{\"path\": \"test_dir\"}";
+    const output = try executor.executeDeleteDirectory(case);
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("Success", output);
+}
+
+test "Delete directory non-existent dir failure" {
+    const gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+
+    const output = try executor.executeDeleteDirectory("{\"path\": \"non_existent_dir\"}");
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("Error deleting directory: error.FileNotFound", output);
+}
+
+test "Delete directory empty path failure" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+
+    const output = try executor.executeDeleteDirectory("{\"path\": \"\"}");
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("No path provided", output);
+}

--- a/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
@@ -33,9 +33,9 @@ test "Delete file success case" {
 
     var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
 
-    var file = try std.Io.Dir.createFile(dir, io, "./testr", .{ .permissions = .default_file });
+    var file = try std.Io.Dir.createFile(dir, io, "./tests/testr", .{ .permissions = .default_file });
     defer file.close(io);
-    const case = "{\"path\": \"./testr\"}";
+    const case = "{\"path\": \"./tests/testr\"}";
     const output = try executor.executeDeleteFile(case);
     defer gpa.free(output);
     try std.testing.expectEqualStrings("Success", output);

--- a/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
@@ -18,10 +18,9 @@ const CommandExecutor = struct {
         };
 
         std.Io.Dir.cwd().deleteTree(self.io, path) catch |err| {
-            return try std.fmt.allocPrint(self.allocator, "Error deleting file: {s}",  .{@errorName(err)});
+            return try std.fmt.allocPrint(self.allocator, "Error deleting file: {s}", .{@errorName(err)});
         };
         return try self.allocator.dupe(u8, "Success");
-
     }
 };
 
@@ -34,7 +33,7 @@ test "Delete file success case" {
 
     var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
 
-    var file = try std.Io.Dir.createFile(dir, io, "./testr", .{ .permissions = .default_file } );
+    var file = try std.Io.Dir.createFile(dir, io, "./testr", .{ .permissions = .default_file });
     defer file.close(io);
     const case = "{\"path\": \"./testr\"}";
     const output = try executor.executeDeleteFile(case);

--- a/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_delete_file_test.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const json = std.json;
+
+const CommandExecutor = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+
+    fn executeDeleteFile(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
+        const DeleteFileParameters = struct { path: []const u8 };
+        const parsed = try json.parseFromSlice(DeleteFileParameters, self.allocator, raw_json, .{});
+        defer parsed.deinit();
+
+        const path = parsed.value.path;
+        if (path.len == 0) return try self.allocator.dupe(u8, "No path provided");
+
+        _ = std.Io.Dir.cwd().statFile(self.io, path, .{}) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error deleting file: {}", .{err});
+        };
+
+        std.Io.Dir.cwd().deleteTree(self.io, path) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error deleting file: {s}",  .{@errorName(err)});
+        };
+        return try self.allocator.dupe(u8, "Success");
+
+    }
+};
+
+test "Delete file success case" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const dir = std.Io.Dir.cwd();
+    const io = threaded.io();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+
+    var file = try std.Io.Dir.createFile(dir, io, "./testr", .{ .permissions = .default_file } );
+    defer file.close(io);
+    const case = "{\"path\": \"./testr\"}";
+    const output = try executor.executeDeleteFile(case);
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("Success", output);
+}
+
+test "Delete file non-existent file failure" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+
+    const output = try executor.executeDeleteFile("{\"path\": \"non_existent_file\"}");
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("Error deleting file: error.FileNotFound", output);
+}
+
+test "Delete file empty path failure" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+
+    const output = try executor.executeDeleteFile("{\"path\": \"\"}");
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("No path provided", output);
+}

--- a/Payload_Type/rango/rango/agent_code/tests/execute_ls_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_ls_test.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const json = std.json;
+
+const CommandExecutor = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+
+    fn executeLs(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
+       const ExecuteLsParameters =  struct { path: []const u8 };
+        const parsed = try json.parseFromSlice(ExecuteLsParameters, self.allocator, raw_json, .{});
+        defer parsed.deinit();
+
+        const path = parsed.value.path;
+        if (path.len == 0) return try self.allocator.dupe(u8, "No path provided");
+        
+        var dir = std.Io.Dir.cwd().openDir(self.io, path, .{ .iterate = true }) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error listing files: {s} ", .{ @errorName(err) });
+        };
+        defer dir.close(self.io);
+        var output = std.ArrayList(u8).empty;
+        defer output.deinit(self.allocator);
+
+        var iterator = dir.iterate();
+        while (try iterator.next(self.io)) |entry| {
+            try output.appendSlice(self.allocator, entry.name);
+            try output.append(self.allocator, '\n');
+        }
+        return try output.toOwnedSlice(self.allocator);
+    }
+};
+
+test "ls current directory success" {
+    const gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+    const case = "{\"path\": \".\"}";
+    const output = try executor.executeLs(case);
+    defer gpa.free(output);
+    try std.testing.expect(output.len > 0);
+}
+
+test "Empty directory path test failure" {
+    const gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+    const case = "{\"path\": \"\"}";
+    const output = try executor.executeLs(case);
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("No path provided", output);
+}

--- a/Payload_Type/rango/rango/agent_code/tests/execute_ls_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_ls_test.zig
@@ -6,15 +6,15 @@ const CommandExecutor = struct {
     io: std.Io,
 
     fn executeLs(self: *CommandExecutor, raw_json: []const u8) ![]const u8 {
-       const ExecuteLsParameters =  struct { path: []const u8 };
+        const ExecuteLsParameters = struct { path: []const u8 };
         const parsed = try json.parseFromSlice(ExecuteLsParameters, self.allocator, raw_json, .{});
         defer parsed.deinit();
 
         const path = parsed.value.path;
         if (path.len == 0) return try self.allocator.dupe(u8, "No path provided");
-        
+
         var dir = std.Io.Dir.cwd().openDir(self.io, path, .{ .iterate = true }) catch |err| {
-            return try std.fmt.allocPrint(self.allocator, "Error listing files: {s} ", .{ @errorName(err) });
+            return try std.fmt.allocPrint(self.allocator, "Error listing files: {s} ", .{@errorName(err)});
         };
         defer dir.close(self.io);
         var output = std.ArrayList(u8).empty;
@@ -31,7 +31,7 @@ const CommandExecutor = struct {
 
 test "ls current directory success" {
     const gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
 
     var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
@@ -43,7 +43,7 @@ test "ls current directory success" {
 
 test "Empty directory path test failure" {
     const gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
 
     var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };

--- a/Payload_Type/rango/rango/agent_code/tests/execute_pwd_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_pwd_test.zig
@@ -5,7 +5,7 @@ const CommandExecutor = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
 
-    fn executePwd(self: *CommandExecutor) ![] const u8 {
+    fn executePwd(self: *CommandExecutor) ![]const u8 {
         const cwd_z = std.process.currentPathAlloc(self.io, self.allocator) catch |err| {
             return try std.fmt.allocPrint(self.allocator, "Error doing pwd: {}", .{err});
         };
@@ -13,14 +13,14 @@ const CommandExecutor = struct {
         const cwd = try self.allocator.dupe(u8, cwd_z[0..cwd_z.len]);
         defer self.allocator.free(cwd);
         std.debug.print("pwd: {s}", .{cwd});
-        return try self.allocator.dupe(u8, "success"); 
+        return try self.allocator.dupe(u8, "success");
     }
 };
 
 //pwd is a bit restricted since it does not take params from the user
 test "pwd success" {
     var gpa = std.testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
 
     var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };

--- a/Payload_Type/rango/rango/agent_code/tests/execute_pwd_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_pwd_test.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const json = std.json;
+
+const CommandExecutor = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+
+    fn executePwd(self: *CommandExecutor) ![] const u8 {
+        const cwd_z = std.process.currentPathAlloc(self.io, self.allocator) catch |err| {
+            return try std.fmt.allocPrint(self.allocator, "Error doing pwd: {}", .{err});
+        };
+        defer self.allocator.free(cwd_z);
+        const cwd = try self.allocator.dupe(u8, cwd_z[0..cwd_z.len]);
+        defer self.allocator.free(cwd);
+        std.debug.print("pwd: {s}", .{cwd});
+        return try self.allocator.dupe(u8, "success"); 
+    }
+};
+
+//pwd is a bit restricted since it does not take params from the user
+test "pwd success" {
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{}); 
+    defer threaded.deinit();
+
+    var executor = CommandExecutor{ .allocator = gpa, .io = threaded.io() };
+    const output = try executor.executePwd();
+    defer gpa.free(output);
+    try std.testing.expectEqualStrings("success", output);
+}
+
+test "pwd out of memory" {
+    var threaded = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
+    var failing_alloc = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    var executor = CommandExecutor{ .allocator = failing_alloc.allocator(), .io = threaded.io() };
+
+    try std.testing.expectError(error.OutOfMemory, executor.executePwd());
+}

--- a/Payload_Type/rango/rango/agent_code/tests/execute_shell_test.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/execute_shell_test.zig
@@ -28,13 +28,12 @@ const CommandExecutor = struct {
 };
 
 test "shell command execution via JSON" {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    const allocator = gpa.allocator();
-    var threaded = std.Io.Threaded.init(allocator, .{});
+    var gpa = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
     const io = threaded.io();
 
-    var executor = CommandExecutor{ .allocator = allocator, .io = io };
+    var executor = CommandExecutor{ .allocator = gpa, .io = io };
 
     const cases = [_][]const u8{
         "{\"command\": \"ls\"}",
@@ -46,7 +45,7 @@ test "shell command execution via JSON" {
 
     inline for (cases) |raw_json| {
         const output = try executor.executeShell(raw_json);
-        defer allocator.free(output);
+        defer gpa.free(output);
 
         std.debug.print("JSON: {s}\nOutput:\n{s}\n---\n", .{ raw_json, output });
 

--- a/Payload_Type/rango/rango/agent_code/tests/main.zig
+++ b/Payload_Type/rango/rango/agent_code/tests/main.zig
@@ -1,0 +1,8 @@
+comptime {
+    _ = @import("execute_cat_test.zig");
+    _ = @import("execute_delete_directory_test.zig");
+    _ = @import("execute_delete_file_test.zig");
+    _ = @import("execute_ls_test.zig");
+    _ = @import("execute_pwd_test.zig");
+    _ = @import("execute_shell_test.zig");
+}


### PR DESCRIPTION
This PR adds test cases for the following commands:

- [x] shell
- [x] delete file
- [x] delete directory
- [x] cat
- [x] pwd

The following commands are not yet covered but will be soon:
- [ ] download
- [ ] upload
- [ ] make_token
- [ ] rev2self
- [ ] portscan